### PR TITLE
1.0.11 master

### DIFF
--- a/epl-wp-all-import.php
+++ b/epl-wp-all-import.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Property Listings Import CSV, XML WP All Import Add On
  * Plugin URL: https://wordpress.org/plugins/easy-property-listings-xml-csv-import/
  * Description: Import CSV and XML into Easy Property Listings with this WP All Import Add-on
- * Version: 1.0.10
+ * Version: 1.0.11
  * Text Domain: epl-wpimport
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
@@ -26,7 +26,7 @@
  * @package EPL-Import
  * @category Importer
  * @author Merv Barrett
- * @version 1.0.10
+ * @version 1.0.11
  */
 
 // Exit if accessed directly

--- a/includes/importer.php
+++ b/includes/importer.php
@@ -363,7 +363,7 @@ function epl_wpimport_is_post_to_update_depricated( $pid , $xml_node) {
 
 	global $epl_wpimport;
 	//add_action('pmxi_before_post_import', 'epl_wpimport_post_saved_notification', 10, 1);
-
+	$epl_wpimport->log( '<b>deprecated version running<b>' );
 	$live_import	=	function_exists('epl_get_option')  ?  epl_get_option('epl_wpimport_skip_update') : 'off';
 	if ( $live_import == 'on' && get_post_meta($pid,'property_mod_date',true) != '' ) {
 		/** only update posts if new data is available **/
@@ -395,6 +395,7 @@ function epl_wpimport_is_post_to_update( $continue_import,$pid , $xml_node,$impo
 
 	global $epl_wpimport;
 	//add_action('pmxi_before_post_import', 'epl_wpimport_post_saved_notification', 10, 1);
+	$epl_wpimport->log( '<b>latest version running<b>' );
 
 	$live_import	=	function_exists('epl_get_option')  ?  epl_get_option('epl_wpimport_skip_update') : 'off';
 	if ( $live_import == 'on' && get_post_meta($pid,'property_mod_date',true) != '' ) {
@@ -424,7 +425,7 @@ function epl_wpimport_is_post_to_update( $continue_import,$pid , $xml_node,$impo
 if( defined('PMXI_VERSION') && version_compare( PMXI_VERSION, '4.5.0', '<' ) ) {
 	add_filter('wp_all_import_is_post_to_update', 'epl_wpimport_is_post_to_update_depricated', 10, 2);
 } else {
-	add_filter('wp_all_import_is_post_to_update', 'epl_wpimport_is_post_to_update', 10, 2);
+	add_filter('wp_all_import_is_post_to_update', 'epl_wpimport_is_post_to_update', 10, 4);
 }
 
 /** dont let wp all import pro delete image mod date **/

--- a/includes/importer.php
+++ b/includes/importer.php
@@ -421,8 +421,6 @@ function epl_wpimport_is_post_to_update( $continue_import,$pid , $xml_node,$impo
 	// Don't update
 	return true;
 }
-add_filter('wp_all_import_is_post_to_update', 'epl_wpimport_is_post_to_update', 10, 4);
-
 if( defined('PMXI_VERSION') && version_compare( PMXI_VERSION, '4.5.0', '<' ) ) {
 	add_filter('wp_all_import_is_post_to_update', 'epl_wpimport_is_post_to_update_depricated', 10, 2);
 } else {

--- a/languages/epl-wpimport.pot
+++ b/languages/epl-wpimport.pot
@@ -1,9 +1,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings XML CSV Import 1.0.8\n"
+"Project-Id-Version: Easy Property Listings XML CSV Import 1.0.11\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2017-03-29 14:40+0800\n"
+"POT-Creation-Date: 2017-10-10 16:23+0800\n"
 "PO-Revision-Date: 2015-09-09 16:02+0800\n"
 "Last-Translator: Merv Barrett <suppport@realestateconnected.com.au>\n"
 "Language-Team: Real Estate Connected <suppport@realestateconnected.com.au>\n"
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Record Skipping Disabled"
 msgstr ""
 
-#: includes/importer.php:158 includes/importer.php:310
+#: includes/importer.php:158 includes/importer.php:320
 msgid "EPL IMPORTER"
 msgstr ""
 
@@ -122,55 +122,55 @@ msgstr ""
 msgid "New Images, Updating"
 msgstr ""
 
-#: includes/importer.php:281
+#: includes/importer.php:291
 msgid "EPL Image Processing Started : Old Mod Date : "
 msgstr ""
 
-#: includes/importer.php:281
+#: includes/importer.php:291
 msgid "New Mod Date : "
 msgstr ""
 
-#: includes/importer.php:281
+#: includes/importer.php:291
 msgid "Live Import : "
 msgstr ""
 
-#: includes/importer.php:285
+#: includes/importer.php:295
 msgid "EPL Import : Live import off, default WP All Import functions"
 msgstr ""
 
-#: includes/importer.php:291
+#: includes/importer.php:301
 msgid "Images unchanged, skipping image deletion"
 msgstr ""
 
-#: includes/importer.php:294
+#: includes/importer.php:304
 msgid "Images changes detected, deleting images"
 msgstr ""
 
-#: includes/importer.php:313
+#: includes/importer.php:323
 msgid "Record Skipped"
 msgstr ""
 
-#: includes/importer.php:324
+#: includes/importer.php:334
 msgid "Date modified, updating..."
 msgstr ""
 
-#: includes/importer.php:328
+#: includes/importer.php:338
 msgid "Modified Listing, updating..."
 msgstr ""
 
-#: includes/importer.php:332
+#: includes/importer.php:342
 msgid "Updating Field..."
 msgstr ""
 
-#: includes/importer.php:336
+#: includes/importer.php:346
 msgid "Listing Modified Time Unchanged, Skipping Record Update."
 msgstr ""
 
-#: includes/importer.php:340
+#: includes/importer.php:350
 msgid "Updating Fields:"
 msgstr ""
 
-#: includes/importer.php:344
+#: includes/importer.php:354
 msgid "Skipped, previously imported record found for:"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Contributors: mervb1
 Donate link: https://easypropertylistings.com.au/support-the-site/
 Tags: extension, easy property listings, wp all import, wp all import pro, csv, xml, xls, import, reaxml, jupix, BLM, MLS, real estate listings, property, rental, land, rural, business, commercial
 Requires at least: 3.3
-Tested up to: 4.8
+Tested up to: 4.8.2
 
-Stable Tag: 1.0.9
+Stable Tag: 1.0.10
 
 License: GNU Version 2 or Any Later Version
 
@@ -48,6 +48,10 @@ Supported formats are CSV, XML and XLS files with full support for the Australia
 
 
 == Change log ==
+
+= 1.0.11 October 10, 2017 =
+
+* Fix: Critical fix for WP All Import Pro 4.5, this fix is backward compatible with 4.4.5 and earlier versions. Ensure you update the importer add-on to minimise listing processing data.
 
 = 1.0.10 July 7, 2017 =
 


### PR DESCRIPTION
* Fix: Critical fix for WP All Import Pro 4.5, this fix is backward compatible with 4.4.5 and earlier versions. Ensure you update the importer add-on to minimise listing processing data.